### PR TITLE
Update action to use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: "The GitHub token for your repo"
     required: true
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Node 16 is being deprecated from Github actions and they recommend using node 20.