### PR TITLE
fix: update readme to match release scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: DevCycleHQ/feature-flag-code-usage-action@1.2.0
+      - uses: DevCycleHQ/feature-flag-code-usage-action@v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           client-id: ${{ secrets.DVC_CLIENT_ID }}


### PR DESCRIPTION
release scripts were failing with sed on readme because it wasn't finding a match 