### PR TITLE
fix: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "resolutions": {
         "minimatch": "^9.0.7",
         "tar": "^7.5.11",
-        "brace-expansion@npm:^2.0.1": "2.0.3",
-        "brace-expansion@npm:^2.0.2": "2.0.3",
-        "picomatch": "2.3.2"
+        "brace-expansion@npm:^2.0.1": "^2.0.3",
+        "brace-expansion@npm:^2.0.2": "^2.0.3",
+        "picomatch": "^2.3.2"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     },
     "resolutions": {
         "minimatch": "^9.0.7",
-        "tar": "^7.5.11"
+        "tar": "^7.5.11",
+        "brace-expansion@npm:^2.0.1": "2.0.3",
+        "brace-expansion@npm:^2.0.2": "2.0.3",
+        "picomatch@npm:^2.3.1": "2.3.2"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "tar": "^7.5.11",
         "brace-expansion@npm:^2.0.1": "2.0.3",
         "brace-expansion@npm:^2.0.2": "2.0.3",
-        "picomatch@npm:^2.3.1": "2.3.2"
+        "picomatch": "2.3.2"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,13 +3110,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
-  languageName: node
-  linkType: hard
-
 "pirates@npm:^4.0.4":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,12 +1296,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+"brace-expansion@npm:2.0.3":
+  version: 2.0.3
+  resolution: "brace-expansion@npm:2.0.3"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
   languageName: node
   linkType: hard
 
@@ -3103,7 +3103,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:2.3.2":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,12 +1296,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:2.0.3":
-  version: 2.0.3
-  resolution: "brace-expansion@npm:2.0.3"
+"brace-expansion@npm:^2.0.3":
+  version: 2.1.0
+  resolution: "brace-expansion@npm:2.1.0"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
+  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
   languageName: node
   linkType: hard
 
@@ -3103,7 +3103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:2.3.2":
+"picomatch@npm:^2.3.2":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61


### PR DESCRIPTION
## Summary

- Bumped `brace-expansion` to 2.0.3 via yarn resolution to resolve medium severity vulnerability (alert #57)
- Bumped `picomatch` to 2.3.2 via yarn resolution to resolve medium severity vulnerability (alert #56)