### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "brace-expansion@npm:^2.0.1": "^2.0.3",
         "brace-expansion@npm:^2.0.2": "^2.0.3",
         "picomatch": "^2.3.2",
-        "ip-address@npm:^9.0.5": "^10.1.1"
+        "socks": "^2.8.9"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "tar": "^7.5.11",
         "brace-expansion@npm:^2.0.1": "^2.0.3",
         "brace-expansion@npm:^2.0.2": "^2.0.3",
-        "picomatch": "^2.3.2"
+        "picomatch": "^2.3.2",
+        "ip-address@npm:^9.0.5": "^10.1.1"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/package.json
+++ b/package.json
@@ -38,11 +38,7 @@
     },
     "resolutions": {
         "minimatch": "^9.0.7",
-        "tar": "^7.5.11",
-        "brace-expansion@npm:^2.0.1": "^2.0.3",
-        "brace-expansion@npm:^2.0.2": "^2.0.3",
-        "picomatch": "^2.3.2",
-        "socks": "^2.8.9"
+        "tar": "^7.5.11"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,13 +2025,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: "npm:1.1.0"
-    sprintf-js: "npm:^1.1.3"
-  checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 
@@ -2640,13 +2637,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
   languageName: node
   linkType: hard
 
@@ -3381,13 +3371,6 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,13 +3347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.8.3":
-  version: 2.8.4
-  resolution: "socks@npm:2.8.4"
+"socks@npm:^2.8.9":
+  version: 2.8.9
+  resolution: "socks@npm:2.8.9"
   dependencies:
-    ip-address: "npm:^9.0.5"
+    ip-address: "npm:^10.1.1"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10c0/00c3271e233ccf1fb83a3dd2060b94cc37817e0f797a93c560b9a7a86c4a0ec2961fb31263bdd24a3c28945e24868b5f063cd98744171d9e942c513454b50ae5
+  checksum: 10c0/2d4350c31142b0931eb1758825b426bcbf4bfb5eed682ca48bc46dc9e7d1930ec366ea574ad49fc6c1fd9e9e17ce243be0ef13e31fc4b0319d9093f1fb19743c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,12 +1296,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "brace-expansion@npm:2.1.0"
+"brace-expansion@npm:^2.0.2":
+  version: 2.1.1
+  resolution: "brace-expansion@npm:2.1.1"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
+  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
   languageName: node
   linkType: hard
 
@@ -3093,7 +3093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.3.2":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
@@ -3347,7 +3347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.8.9":
+"socks@npm:^2.8.3":
   version: 2.8.9
   resolution: "socks@npm:2.8.9"
   dependencies:


### PR DESCRIPTION
## Summary

Resolved Dependabot security alerts using lockfile-only bumps. The patched versions of all affected packages fall within existing semver ranges already declared in the dependency tree, so no `resolutions` overrides in `package.json` are needed. Running `yarn up --recursive` is sufficient to pull in the patched versions.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #58 | `ip-address` (transitive via `socks`) | medium | `socks@2.8.9` (range `^2.8.3`) natively pulls `ip-address@10.2.0` — lockfile bump only |
| #57 | `brace-expansion` | medium | Bumped to `2.1.1` via existing `^2.0.2` range — lockfile bump only |
| #56, #55 | `picomatch` | moderate | Bumped to `2.3.2` via existing `^2.3.1` range — lockfile bump only |

## Approach

All three packages have patched versions that satisfy their declared semver ranges. No `package.json` changes to the `resolutions` block are required. The previous commits in this PR that added `resolutions` overrides for these packages have been cleaned up in favour of plain lockfile bumps.