### PR TITLE
chore: reduce dependency resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "resolutions": {
         "minimatch": "^9.0.7",
-        "tar": "^7.5.11"
+        "tar": "^7.5.15"
     },
     "packageManager": "yarn@4.9.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,16 +3495,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.11":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:^7.5.15":
+  version: 7.5.15
+  resolution: "tar@npm:7.5.15"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/8f039edb1d12fdd7df6c6f9877d125afe9f3da3f5f9317df326fdd090d48793d6998cede1506a1471f3e3a250db270a89dace28005eb5e99c5a9132d704ac956
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- reduces dependency `resolutions` where patched versions are now selected naturally
- bumps remaining resolution floors or same-major package ranges where needed
- updates `yarn.lock`

## Testing
- `yarn install --immutable`