### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     },
     "resolutions": {
         "@babel/core": ">=7.29.6 <8",
+        "brace-expansion": ">=2.1.2 <3",
         "js-yaml": ">=3.15.0 <4",
         "minimatch": "^9.0.7",
         "tar": ">=7.5.16 <8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,12 +1400,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+"brace-expansion@npm:>=2.1.2 <3":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `brace-expansion` to 2.1.2 to resolve high-severity DoS vulnerability (CVE-2026-13149)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #67 | `brace-expansion` | **high** | Bumped to 2.1.2 via yarn resolution `>=2.1.2 <3` |

`brace-expansion` is a transitive dependency via `minimatch`. A yarn `resolutions` entry forces the patched version. The bounded range (`<3`) keeps within the same major version to avoid breaking changes.

All existing tests pass.