### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     },
     "resolutions": {
         "@babel/core": ">=7.29.6 <8",
-        "brace-expansion": ">=2.1.2 <3",
+        "brace-expansion": ">=2.1.3 <3",
+        "ip-address": ">=10.3.1 <11",
         "js-yaml": ">=3.15.0 <4",
         "minimatch": "^9.0.7",
         "tar": ">=7.5.16 <8",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     },
     "resolutions": {
         "@babel/core": ">=7.29.6 <8",
+        "brace-expansion": ">=2.1.2 <3",
         "js-yaml": ">=3.15.0 <4",
         "minimatch": "^9.0.7",
         "tar": ">=7.5.16 <8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,12 +1400,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+"brace-expansion@npm:>=2.1.2 <3":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,12 +1400,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:>=2.1.2 <3":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+"brace-expansion@npm:>=2.1.3 <3":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
@@ -2134,10 +2134,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+"ip-address@npm:>=10.3.1 <11":
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 4 open Dependabot security alerts by bumping vulnerable transitive dependencies

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #71 | `ip-address` | **high** | Bumped to 10.4.0 via resolution (was 10.2.0) |
| #70 | `ip-address` | **medium** | Bumped to 10.4.0 via resolution (was 10.2.0) |
| #69 | `ip-address` | **medium** | Bumped to 10.4.0 via resolution (was 10.2.0) |
| #68 | `brace-expansion` | **high** | Bumped to 2.1.4 via resolution (was 2.1.2) |

Both packages are transitive dependencies resolved via yarn `resolutions` in `package.json`.